### PR TITLE
feat: track user traffic by node

### DIFF
--- a/app/Http/Controllers/V2/Admin/StatController.php
+++ b/app/Http/Controllers/V2/Admin/StatController.php
@@ -88,5 +88,20 @@ class StatController extends Controller
             'data' => $statisticalService->getRanking($request->input('type'), $request->input('limit') ?? 20)
         ];
     }
+
+    public function userNodeTraffic(Request $request)
+    {
+        $request->validate([
+            'start_at' => '',
+            'end_at' => ''
+        ]);
+
+        $statisticalService = new StatisticalService();
+        $statisticalService->setStartAt($request->input('start_at'));
+        $statisticalService->setEndAt($request->input('end_at'));
+        return [
+            'data' => $statisticalService->getUserNodeTraffic()
+        ];
+    }
 }
 

--- a/app/Services/ServerService.php
+++ b/app/Services/ServerService.php
@@ -227,9 +227,8 @@ class ServerService
     public function log(int $userId, int $serverId, int $u, int $d, float $rate, string $method)
     {
         if (($u + $d) < 10240) return true;
-        $timestamp = strtotime(date('Y-m-d'));
-        $serverLog = ServerLog::where('log_at', '>=', $timestamp)
-            ->where('log_at', '<', $timestamp + 3600)
+        $timestamp = floor(time() / 3600) * 3600;
+        $serverLog = ServerLog::where('log_at', $timestamp)
             ->where('server_id', $serverId)
             ->where('user_id', $userId)
             ->where('rate', $rate)

--- a/app/Services/StatisticalService.php
+++ b/app/Services/StatisticalService.php
@@ -7,6 +7,7 @@ use App\Models\Stat;
 use App\Models\StatServer;
 use App\Models\StatUser;
 use App\Models\User;
+use App\Models\ServerLog;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 
@@ -203,6 +204,26 @@ class StatisticalService {
                     ->get();
             }
         }
+    }
+
+    public function getUserNodeTraffic()
+    {
+        $startAt = $this->startAt ?? strtotime(date('Y-m-d'));
+        $endAt = $this->endAt ?? strtotime('+1 day', $startAt);
+
+        return ServerLog::where('log_at', '>=', $startAt)
+            ->where('log_at', '<', $endAt)
+            ->select([
+                'user_id',
+                'server_id',
+                'method',
+                'log_at',
+                DB::raw('SUM(u) as u'),
+                DB::raw('SUM(d) as d')
+            ])
+            ->groupBy('user_id', 'server_id', 'method', 'log_at')
+            ->orderBy('log_at', 'ASC')
+            ->get();
     }
 
     public function getRanking($type, $limit = 20)

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -8,6 +8,7 @@ use App\Jobs\TrafficFetchJob;
 use App\Models\Order;
 use App\Models\Plan;
 use App\Models\User;
+use App\Services\ServerService;
 
 class UserService
 {
@@ -230,6 +231,10 @@ class UserService
         TrafficFetchJob::dispatch($data, $server, $protocol);
         StatUserJob::dispatch($data, $server, $protocol, 'd');
         StatServerJob::dispatch($data, $server, $protocol, 'd');
+        $serverService = new ServerService();
+        foreach ($data as $userId => $traffic) {
+            $serverService->log($userId, $server['id'], $traffic[0], $traffic[1], $server['rate'], $protocol);
+        }
     }
 
     public static function getMaxId()


### PR DESCRIPTION
## Summary
- log hourly traffic per user and server
- expose API to fetch per-user node usage stats

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/v2board/vendor/autoload.php')*
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_b_68ba3ad077dc832da5df135ebf5c6ddd