### PR TITLE
fix(auth): 收紧第三方登录重定向白名单匹配

### DIFF
--- a/app/Http/Controllers/V1/Admin/UserController.php
+++ b/app/Http/Controllers/V1/Admin/UserController.php
@@ -735,6 +735,9 @@ class UserController extends Controller
         if (in_array($scheme, ['http', 'https'], true) && empty($parts['host'])) {
             abort(422, 'redirect_uri is invalid');
         }
+        if (in_array($scheme, ['http', 'https'], true) && (isset($parts['user']) || isset($parts['pass']))) {
+            abort(422, 'redirect_uri is invalid');
+        }
 
         if (!$this->isThirdPartyRedirectAllowed($redirectUri)) {
             abort(422, 'redirect_uri is not allowed');
@@ -755,7 +758,7 @@ class UserController extends Controller
                 continue;
             }
             if (stripos($allowed, '://') !== false) {
-                if (str_starts_with($redirectUri, $allowed)) {
+                if ($this->isAllowedAbsoluteRedirectUri($redirectUri, $allowed)) {
                     return true;
                 }
                 continue;
@@ -780,6 +783,40 @@ class UserController extends Controller
         }
 
         return false;
+    }
+
+    private function isAllowedAbsoluteRedirectUri(string $redirectUri, string $allowedUri): bool
+    {
+        $redirect = parse_url($redirectUri);
+        $allowed = parse_url($allowedUri);
+        if ($redirect === false || $allowed === false) {
+            return false;
+        }
+
+        $redirectScheme = strtolower($redirect['scheme'] ?? '');
+        $allowedScheme = strtolower($allowed['scheme'] ?? '');
+        $redirectHost = strtolower($redirect['host'] ?? '');
+        $allowedHost = strtolower($allowed['host'] ?? '');
+
+        if ($redirectScheme === '' || $allowedScheme === '' || $redirectHost === '' || $allowedHost === '') {
+            return false;
+        }
+        if ($redirectScheme !== $allowedScheme || $redirectHost !== $allowedHost) {
+            return false;
+        }
+        if (($redirect['port'] ?? null) !== ($allowed['port'] ?? null)) {
+            return false;
+        }
+
+        $allowedPath = $allowed['path'] ?? '';
+        if ($allowedPath === '') {
+            return true;
+        }
+        $redirectPath = $redirect['path'] ?? '';
+        if ($redirectPath === $allowedPath) {
+            return true;
+        }
+        return str_starts_with($redirectPath, rtrim($allowedPath, '/') . '/');
     }
 
     private function hostMatchesDomain(string $host, string $domain): bool

--- a/tests/Unit/ThirdPartyRedirectWhitelistTest.php
+++ b/tests/Unit/ThirdPartyRedirectWhitelistTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Http\Controllers\V1\Admin\UserController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Tests\TestCase;
+
+class ThirdPartyRedirectWhitelistTest extends TestCase
+{
+    private function invokePrivate(object $object, string $method, array $args = [])
+    {
+        $reflection = new \ReflectionMethod($object, $method);
+        $reflection->setAccessible(true);
+        return $reflection->invokeArgs($object, $args);
+    }
+
+    public function testAbsoluteWhitelistRequiresSameHostNotPrefix(): void
+    {
+        config()->set('v2board.third_party_login_redirect_uri_whitelist', [
+            'https://trusted.example.com'
+        ]);
+
+        $controller = new UserController();
+
+        $this->assertTrue($this->invokePrivate($controller, 'isThirdPartyRedirectAllowed', [
+            'https://trusted.example.com/callback'
+        ]));
+
+        $this->assertFalse($this->invokePrivate($controller, 'isThirdPartyRedirectAllowed', [
+            'https://trusted.example.com.evil.tld/callback'
+        ]));
+
+        $this->assertFalse($this->invokePrivate($controller, 'isThirdPartyRedirectAllowed', [
+            'https://trusted.example.com@evil.tld/callback'
+        ]));
+    }
+
+    public function testAbsoluteWhitelistWithPathStillAllowsSubpaths(): void
+    {
+        config()->set('v2board.third_party_login_redirect_uri_whitelist', [
+            'https://trusted.example.com/oauth/callback'
+        ]);
+
+        $controller = new UserController();
+
+        $this->assertTrue($this->invokePrivate($controller, 'isThirdPartyRedirectAllowed', [
+            'https://trusted.example.com/oauth/callback/complete'
+        ]));
+
+        $this->assertFalse($this->invokePrivate($controller, 'isThirdPartyRedirectAllowed', [
+            'https://trusted.example.com/oauth/other'
+        ]));
+    }
+
+    public function testSanitizeRejectsHttpUserInfoRedirectUri(): void
+    {
+        $controller = new UserController();
+
+        $this->expectException(HttpException::class);
+        $this->invokePrivate($controller, 'sanitizeThirdPartyRedirectUri', [
+            'https://trusted.example.com@evil.tld/callback'
+        ]);
+    }
+}


### PR DESCRIPTION
### Motivation
- 修复第三方登录重定向白名单对包含 scheme 的条目使用前缀匹配导致的绕过风险（例如 `https://trusted.example.com.evil.tld` 或包含 `@` 的 userinfo 情况）。
- 防止攻击者通过构造看似受信任的重定向 URI 获取授权码并兑换访问令牌，从而造成高危安全漏洞。

### Description
- 在 `sanitizeThirdPartyRedirectUri` 中新增对 `http/https` 含有 userinfo (`user:pass@host`) 的拒绝逻辑以避免主机混淆（新增检查 `isset($parts['user']) || isset($parts['pass'])`）。
- 将针对包含 scheme 的白名单条目由不安全的 `str_starts_with($redirectUri, $allowed)` 前缀匹配替换为 `isAllowedAbsoluteRedirectUri` 结构化比较，要求 `scheme`/`host`/`port` 完全匹配并对允许的路径支持子路径放行策略。
- 新增 `isAllowedAbsoluteRedirectUri` 私有方法对绝对 URL 白名单项做严格的 URI 组件校验并保留基于路径的子路径放行行为。
- 添加单元测试文件 `tests/Unit/ThirdPartyRedirectWhitelistTest.php`，覆盖合法回调、前缀相似域名绕过、含 `@` userinfo 拒绝以及带路径白名单的子路径允许场景。

### Testing
- 安装依赖并生成自动加载：执行 `composer install` 成功。 
- 仅运行新增测试：`php ./vendor/bin/phpunit --filter ThirdPartyRedirectWhitelistTest`，结果为 `OK (3 tests, 6 assertions)`。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b0ca490220832db56c370859914049)