### PR TITLE
fix: prevent stored XSS in notice modal rendering

### DIFF
--- a/public/theme/default/assets/umi.js
+++ b/public/theme/default/assets/umi.js
@@ -31333,9 +31333,8 @@
                     footer: !1,
                     onCancel: ()=>this.modalVisible()
                 }, this.state.notice.content && l.a.createElement("div", {
-                    className: "notice-content",
-                    dangerouslySetInnerHTML: { __html: this.state.notice.content }
-                })))
+                    className: "notice-content"
+                }, this.state.notice.content)))
             }
         }
         t["default"] = Object(y["c"])(e=>{


### PR DESCRIPTION
### Motivation
- 修复公告弹窗中使用 `dangerouslySetInnerHTML` 将未净化的 `notice.content` 原样注入 DOM 导致的存储型 XSS 漏洞，因为后端保存的 `content` 未做 HTML 过滤或转义。

### Description
- 在 `public/theme/default/assets/umi.js` 中，将公告 Modal 渲染从 `dangerouslySetInnerHTML: { __html: this.state.notice.content }` 修改为将 `this.state.notice.content` 作为普通子节点文本渲染以让 React 自动转义，未改变原有弹窗交互逻辑。
- 本次变更只涉及该前端打包文件的渲染代码，没有修改后端验证或其它文件。

### Testing
- 已使用 `rg -n "dangerouslySetInnerHTML|notice-content|modalVisible\(e\)" public/theme/default/assets/umi.js app -S` 确认原易受攻击的渲染位置并在修改后验证删除了 `dangerouslySetInnerHTML`，命令执行成功。
- 已通过 `git diff -- public/theme/default/assets/umi.js` 检查并确认差异为期望的替换，且使用 `git commit` 提交变更，操作成功。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b0ddbd2f98832db2c8e5158ee1ca5a)