### PR TITLE
fix(auth): 不再在 loginWithMailLink API 返回魔法登录链接

### DIFF
--- a/app/Http/Controllers/V1/Passport/AuthController.php
+++ b/app/Http/Controllers/V1/Passport/AuthController.php
@@ -72,7 +72,7 @@ class AuthController extends Controller
         ]);
 
         return response([
-            'data' => $link
+            'data' => true
         ]);
 
     }


### PR DESCRIPTION
### Motivation
- 修复 `loginWithMailLink` 将包含一次性 `verify` token 的魔法登录链接直接返回给未认证调用者，从而导致仅凭邮箱即可接管账户的高危认证绕过。

### Description
- 在 `app/Http/Controllers/V1/Passport/AuthController.php` 的 `loginWithMailLink` 中保留邮件发送逻辑但不再返回魔法链接，改为返回通用成功负载（`data: true`），以防止 token 泄露。

### Testing
- 运行了语法检查 `php -l app/Http/Controllers/V1/Passport/AuthController.php`，检查通过（无语法错误）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b0f669e450832d83bcdcdf3d7870da)